### PR TITLE
Syntax file up to vim standards

### DIFF
--- a/config/nvim/syntax/coma.vim
+++ b/config/nvim/syntax/coma.vim
@@ -2,6 +2,10 @@
 " Language: Coma
 " Author: Paul Patault paul.patault@ens-paris-saclay.fr
 
+if exists("b:current_syntax")
+  finish
+endif
+
 syn clear
 
 syn case ignore
@@ -36,37 +40,33 @@ syn region  comaPrewrites  start="\["  end="\]"
 
 syn sync lines=250
 
-if !exists("did_coma_syntax_inits")
-  let did_coma_syntax_inits = 1
-  hi link comaComment        Comment
-  hi link comaParam          Ignore
-  hi link comaConstant       Number
-  hi link comaDelimiter      Comment
-  hi link comaIdentifier     Ignore 
-  hi link comaPrimitive      Ignore
-  hi link comaNumber         Number
-  hi link comaOperator       Keyword
-  hi link comaKeyword        Keyword
-  hi link comaTodo           Todo
-  hi link comaType           Type
-  hi link comaTypes          StorageClass
-  hi link comaPrewrites      Special
-  hi link comaDefinition     Ignore
-  hi link comaBoxes          Keyword
-  hi! link Conceal           Keyword
-  set conceallevel=2
+hi link comaComment        Comment
+hi link comaParam          Ignore
+hi link comaConstant       Number
+hi link comaDelimiter      Comment
+hi link comaIdentifier     Ignore
+hi link comaPrimitive      Ignore
+hi link comaNumber         Number
+hi link comaOperator       Keyword
+hi link comaKeyword        Keyword
+hi link comaTodo           Todo
+hi link comaType           Type
+hi link comaTypes          StorageClass
+hi link comaPrewrites      Special
+hi link comaDefinition     Ignore
+hi link comaBoxes          Keyword
+hi! link Conceal           Keyword
+set conceallevel=2
 
-  function! ToggleConcealLevel()
-      if &conceallevel == 0
-          setlocal conceallevel=2
-      else
-          setlocal conceallevel=0
-      endif
-  endfunction
+function! ToggleConcealLevel()
+    if &conceallevel == 0
+        setlocal conceallevel=2
+    else
+        setlocal conceallevel=0
+    endif
+endfunction
 
-  nnoremap <silent> <C-c><C-y> :call ToggleConcealLevel()<CR>
-
-endif
+nnoremap <silent> <C-c><C-y> :call ToggleConcealLevel()<CR>
 
 let b:current_syntax = "coma"
 

--- a/config/nvim/syntax/gospel.vim
+++ b/config/nvim/syntax/gospel.vim
@@ -6,7 +6,7 @@
 "              - 2022 Apr 04 - first very basic version included in OCaml syntax
 "
 " You can put this file in your .vim/syntax, and you have to modify (or create)
-" .vim/after/syntax/c.vim and copy these lines :
+" .vim/after/syntax/ocaml.vim and copy these lines :
 "
 " syn include @GOSPEL syntax/gospel.vim
 " syn region GospelComment matchgroup=GospelComment start="(\*@"rs=e-1 end="\*)" contains=@GOSPEL

--- a/config/nvim/syntax/imp.vim
+++ b/config/nvim/syntax/imp.vim
@@ -2,12 +2,17 @@
 " Language: Impopt
 " Adapte de pascal.vim de Mario Eusebio <bio@dq.fct.unl.pt>
 
+if exists("b:current_syntax")
+  finish
+endif
+
 syn clear
 
 syn case ignore
 
 syn keyword impStatement       return var putchar alloc addr write read staticwrite
-syn keyword impConditional     if else while
+syn keyword impConditional     if else
+syn keyword impRepeat          while
 
 syn keyword impTodo contained   TODO
 
@@ -39,6 +44,7 @@ if !exists("did_imp_syntax_inits")
   let did_imp_syntax_inits = 1
   hi link impStatement      Statement
   hi link impConditional    Conditional
+  hi link impRepeat         Repeat
   hi link impTodo           Todo
   hi link impConstant       Number
   hi link impNumber         Number

--- a/config/nvim/syntax/imp.vim
+++ b/config/nvim/syntax/imp.vim
@@ -40,23 +40,20 @@ syn keyword impFunction node function type const
 
 syn sync lines=250
 
-if !exists("did_imp_syntax_inits")
-  let did_imp_syntax_inits = 1
-  hi link impStatement      Statement
-  hi link impConditional    Conditional
-  hi link impRepeat         Repeat
-  hi link impTodo           Todo
-  hi link impConstant       Number
-  hi link impNumber         Number
-  hi link impFloat          Number
-  hi link impOperator       Operator
-  hi link impFunction       Function
-  hi link impType           Type
-  hi link impComment        Comment
-  hi link impStatement      Statement
-  hi link impPack           Type
-  hi link impDelimiter      Identifier
-endif
+hi link impStatement      Statement
+hi link impConditional    Conditional
+hi link impRepeat         Repeat
+hi link impTodo           Todo
+hi link impConstant       Number
+hi link impNumber         Number
+hi link impFloat          Number
+hi link impOperator       Operator
+hi link impFunction       Function
+hi link impType           Type
+hi link impComment        Comment
+hi link impStatement      Statement
+hi link impPack           Type
+hi link impDelimiter      Identifier
 
 let b:current_syntax = "imp"
 

--- a/config/nvim/syntax/kawa.vim
+++ b/config/nvim/syntax/kawa.vim
@@ -41,24 +41,21 @@ syn keyword kawaFunction return putchar main putascii printf
 
 syn sync lines=250
 
-if !exists("did_kawa_syntax_inits")
-  let did_kawa_syntax_inits = 1
-  hi link kawaStatement      Statement
-  hi link kawaConditional    Conditional
-  hi link kawaTodo           Todo
-  hi link kawaConstant       Number
-  hi link kawaNumber         Number
-  hi link kawaFloat          Number
-  hi link kawaOperator       Operator
-  hi link kawaFunction       Function
-  hi link kawaKeyword        Keyword
-  hi link kawaType           Type
-  hi link kawaComment        Comment
-  hi link kawaStatement      Statement
-  hi link kawaPack           Type
-  hi link kawaDelimiter      Identifier
-  hi link kawaAnnotation     PreProc
-endif
+hi link kawaStatement      Statement
+hi link kawaConditional    Conditional
+hi link kawaTodo           Todo
+hi link kawaConstant       Number
+hi link kawaNumber         Number
+hi link kawaFloat          Number
+hi link kawaOperator       Operator
+hi link kawaFunction       Function
+hi link kawaKeyword        Keyword
+hi link kawaType           Type
+hi link kawaComment        Comment
+hi link kawaPack           Type
+hi link kawaDelimiter      Identifier
+hi link kawaAnnotation     PreProc
+
 
 let b:current_syntax = "kawa"
 

--- a/config/nvim/syntax/kawa.vim
+++ b/config/nvim/syntax/kawa.vim
@@ -2,6 +2,10 @@
 " Language: Kawa
 " Author: Paul Patault
 
+if exists("b:current_syntax")
+  finish
+endif
+
 syn clear
 
 syn case ignore

--- a/config/nvim/syntax/lustre.vim
+++ b/config/nvim/syntax/lustre.vim
@@ -2,6 +2,10 @@
 " Language: Lustre
 " Adapte de pascal.vim de Mario Eusebio <bio@dq.fct.unl.pt>
 
+if exists("b:current_syntax")
+  finish
+endif
+
 syn clear
 
 syn case ignore
@@ -69,35 +73,33 @@ syn keyword lusConditional if else then unless until continue fby pre
 
 syn sync lines=250
 
-if !exists("did_lus_syntax_inits")
-  let did_lus_syntax_inits = 1
-  " The default methods for highlighting.  Can be overridden later
-  hi link lusStatement      Statement
-  " hi link lusLabel          Label
-  hi link lusConditional    Conditional
-  hi link lusTodo           Todo
-  hi link lusSet            Todo
-  " hi link lusString               String
-  " hi link lusMatrixDelimiter      Identifier
-  hi link lusConstant       Number
-  hi link lusNumber         Number
-  hi link lusFloat          Number
-  " hi link lusByte           Number
-  hi link lusOperator       Operator
-  hi link lusFunction       Function
-  hi link lusType           Type
-  hi link lusComment        Comment
-  hi link lusStatement      Statement
+let did_lus_syntax_inits = 1
+" The default methods for highlighting.  Can be overridden later
+hi link lusStatement      Statement
+" hi link lusLabel          Label
+hi link lusConditional    Conditional
+hi link lusTodo           Todo
+hi link lusSet            Todo
+" hi link lusString               String
+" hi link lusMatrixDelimiter      Identifier
+hi link lusConstant       Number
+hi link lusNumber         Number
+hi link lusFloat          Number
+" hi link lusByte           Number
+hi link lusOperator       Operator
+hi link lusFunction       Function
+hi link lusType           Type
+hi link lusComment        Comment
+hi link lusStatement      Statement
 
-  hi link lusPack           Type
+hi link lusPack           Type
 
-  "optional highlighting
-  hi link lusDelimiter      Identifier
+"optional highlighting
+hi link lusDelimiter      Identifier
 
-  "hi link lusShowTab       Error
-  "hi link lusShowTabc      Error
-  "hi link lusIdentifier    Identifier
-endif
+"hi link lusShowTab       Error
+"hi link lusShowTabc      Error
+"hi link lusIdentifier    Identifier
 
 let b:current_syntax = "lus"
 

--- a/config/nvim/syntax/patmat.vim
+++ b/config/nvim/syntax/patmat.vim
@@ -2,6 +2,10 @@
 " Language: patmat
 " Author: Paul Patault
 
+if exists("b:current_syntax")
+  finish
+endif
+
 syn clear
 
 syn case ignore
@@ -18,17 +22,14 @@ syn region  patmatConstant   start='"'   end='"'
 
 syn sync lines=250
 
-if !exists("did_patmat_syntax_inits")
-  let did_patmat_syntax_inits = 1
-  hi link patmatStatement      Statement
-  hi link patmatConditional    Conditional
-  hi link patmatConstant       Number
-  hi link patmatOperator       Operator
-  hi link patmatFunction       Function
-  hi link patmatType           Type
-  hi link patmatComment        Comment
-  hi link patmatDelimiter      Identifier
-endif
+hi link patmatStatement      Statement
+hi link patmatConditional    Conditional
+hi link patmatConstant       Number
+hi link patmatOperator       Operator
+hi link patmatFunction       Function
+hi link patmatType           Type
+hi link patmatComment        Comment
+hi link patmatDelimiter      Identifier
 
 let b:current_syntax = "patmat"
 

--- a/config/nvim/syntax/proof.vim
+++ b/config/nvim/syntax/proof.vim
@@ -1,3 +1,7 @@
+if exists("b:current_syntax")
+  finish
+endif
+
 syn clear
 
 " Les mots-cles
@@ -6,11 +10,8 @@ syn keyword proofCommand      assume context define check eval exit type read ch
 
 syn sync lines=250
 
-if !exists("did_proof_syntax_inits")
-  let did_proof_syntax_inits = 1
-  hi link proofTerm         Type
-  hi link proofCommand      Statement
-endif
+hi link proofTerm         Type
+hi link proofCommand      Statement
 
 let b:current_syntax = "proof"
 


### PR DESCRIPTION
Put syntax file up to norm definied in [documentation](https://neovim.io/doc/user/usr_44.html#44.12), specifically the part where syntax file must start with a check for "b:current_syntax".